### PR TITLE
Add Books & Course Companions page

### DIFF
--- a/about.html
+++ b/about.html
@@ -36,6 +36,7 @@
                 <li><a href="about.html" class="nav-link active">ABOUT US</a></li>
                 <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
+                <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
             </ul>
         </nav>
 

--- a/books.html
+++ b/books.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Books & Course Companions - Behavioral Data Science Research Lab</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=VT323&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="cyberpunk-container">
+        <div class="cyber-grid"></div>
+
+        <header class="cyber-header">
+            <div class="header-content">
+                <h1 class="lab-title">
+                    <span class="glitch" data-text="BEHAVIORAL">BEHAVIORAL</span>
+                    <span class="glitch" data-text="DATA">DATA</span>
+                    <span class="glitch" data-text="SCIENCE">SCIENCE</span>
+                    <span class="lab-subtitle">RESEARCH LAB</span>
+                </h1>
+                <div class="pliny-logo">
+                    <div class="pliny-container">
+                        <img src="images/Pliny-the-Pigeon.png" alt="Pliny the Pigeon" class="pliny-image">
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <nav class="cyber-nav">
+            <ul class="nav-list">
+                <li><a href="index.html" class="nav-link">HOME</a></li>
+                <li><a href="about.html" class="nav-link">ABOUT US</a></li>
+                <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
+                <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
+                <li><a href="books.html" class="nav-link active">BOOKS &amp; COURSE COMPANIONS</a></li>
+            </ul>
+        </nav>
+
+        <main class="cyber-main">
+            <section class="page-header">
+                <h2 class="cyber-h2">BOOKS &amp; COURSE COMPANIONS</h2>
+                <div class="cyber-divider"></div>
+            </section>
+
+            <section class="publications-content">
+                <p class="cyber-text">
+                    Books, course companions, and other long-form materials authored by members of the lab. Most recent listed first.
+                </p>
+
+                <div class="publications-grid">
+                    <article class="publication-item">
+                        <div class="publication-year">2026</div>
+                        <h3 class="publication-title">Introduction to Mathematical Modeling in Behavior Science</h3>
+                        <p class="publication-authors">Cox, D. J.</p>
+                        <p class="publication-journal">
+                            A graduate-level introduction to building, fitting, and evaluating quantitative models of behavior. Designed for behavior analysts and behavioral scientists who want to make the move from descriptive analyses to mathematical and computational modeling of behavior-environment relations.
+                        </p>
+                        <div class="publication-links">
+                            <a href="https://behavior-modeling-course-efvay50ed-david-j-coxs-projects.vercel.app/" target="_blank" rel="noopener" class="cyber-button small">VISIT COURSE COMPANION</a>
+                        </div>
+                    </article>
+                </div>
+            </section>
+        </main>
+
+        <footer class="cyber-footer">
+            <div class="footer-content">
+                <p>&copy; 2025 Behavioral Data Science Research Lab</p>
+            </div>
+        </footer>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                 <li><a href="about.html" class="nav-link">ABOUT US</a></li>
                 <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
+                <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
             </ul>
         </nav>
 

--- a/projects.html
+++ b/projects.html
@@ -33,6 +33,7 @@
                 <li><a href="about.html" class="nav-link">ABOUT US</a></li>
                 <li><a href="projects.html" class="nav-link active">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
+                <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
             </ul>
         </nav>
 

--- a/publications.html
+++ b/publications.html
@@ -33,6 +33,7 @@
                 <li><a href="about.html" class="nav-link">ABOUT US</a></li>
                 <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link active">PUBLICATIONS</a></li>
+                <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
             </ul>
         </nav>
 


### PR DESCRIPTION
## Summary
- New `books.html` landing page listing long-form materials authored by the lab; first entry is *Introduction to Mathematical Modeling in Behavior Science*, linking out to the course companion site.
- `BOOKS & COURSE COMPANIONS` nav link added to every page (`index`, `about`, `projects`, `publications`, `books`).
- Reuses existing `publications-grid` / `publication-item` / `cyber-button` styles — no CSS changes.

## Test plan
- [ ] Load each page locally and confirm the new nav item appears and the active state highlights the current page.
- [ ] Open `books.html`, confirm the book entry renders and the `VISIT COURSE COMPANION` button opens the Vercel course site in a new tab.
- [ ] Check mobile width to make sure the 5-item nav still wraps gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)