### PR TITLE
Fix course companion link and add Pliny favicon

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Us - Behavioral Data Science Research Lab</title>
+    <link rel="icon" type="image/png" href="images/Pliny-the-Pigeon.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=VT323&display=swap" rel="stylesheet">
 </head>

--- a/books.html
+++ b/books.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Books & Course Companions - Behavioral Data Science Research Lab</title>
+    <link rel="icon" type="image/png" href="images/Pliny-the-Pigeon.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=VT323&display=swap" rel="stylesheet">
 </head>
@@ -57,7 +58,7 @@
                             A graduate-level introduction to building, fitting, and evaluating quantitative models of behavior. Designed for behavior analysts and behavioral scientists who want to make the move from descriptive analyses to mathematical and computational modeling of behavior-environment relations.
                         </p>
                         <div class="publication-links">
-                            <a href="https://behavior-modeling-course-efvay50ed-david-j-coxs-projects.vercel.app/" target="_blank" rel="noopener" class="cyber-button small">VISIT COURSE COMPANION</a>
+                            <a href="https://behavior-modeling-course.vercel.app/" target="_blank" rel="noopener" class="cyber-button small">VISIT COURSE COMPANION</a>
                         </div>
                     </article>
                 </div>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Behavioral Data Science Research Lab</title>
+    <link rel="icon" type="image/png" href="images/Pliny-the-Pigeon.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=VT323&display=swap" rel="stylesheet">
 </head>

--- a/projects.html
+++ b/projects.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Current Projects - Behavioral Data Science Research Lab</title>
+    <link rel="icon" type="image/png" href="images/Pliny-the-Pigeon.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=VT323&display=swap" rel="stylesheet">
 </head>

--- a/publications.html
+++ b/publications.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Publications - Behavioral Data Science Research Lab</title>
+    <link rel="icon" type="image/png" href="images/Pliny-the-Pigeon.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=VT323&display=swap" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Summary
- Fix the modeling course companion link to use the stable `behavior-modeling-course.vercel.app` URL (was a deployment-specific Vercel URL)
- Add Pliny the Pigeon as the favicon across all pages (index, about, books, projects, publications)

Generated with Claude Code