### PR TITLE
Link to live planarian rig

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,6 +38,7 @@
                 <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
                 <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
+                <li><a href="https://david-j-cox.github.io/planarian-live/" class="nav-link" target="_blank" rel="noopener"><span style="color:#39ff14;">&#9679;</span> LIVE RIG</a></li>
             </ul>
         </nav>
 

--- a/books.html
+++ b/books.html
@@ -35,6 +35,7 @@
                 <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
                 <li><a href="books.html" class="nav-link active">BOOKS &amp; COURSE COMPANIONS</a></li>
+                <li><a href="https://david-j-cox.github.io/planarian-live/" class="nav-link" target="_blank" rel="noopener"><span style="color:#39ff14;">&#9679;</span> LIVE RIG</a></li>
             </ul>
         </nav>
 

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                 <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
                 <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
+                <li><a href="https://david-j-cox.github.io/planarian-live/" class="nav-link" target="_blank" rel="noopener"><span style="color:#39ff14;">&#9679;</span> LIVE RIG</a></li>
             </ul>
         </nav>
 

--- a/projects.html
+++ b/projects.html
@@ -35,6 +35,7 @@
                 <li><a href="projects.html" class="nav-link active">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link">PUBLICATIONS</a></li>
                 <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
+                <li><a href="https://david-j-cox.github.io/planarian-live/" class="nav-link" target="_blank" rel="noopener"><span style="color:#39ff14;">&#9679;</span> LIVE RIG</a></li>
             </ul>
         </nav>
 
@@ -49,6 +50,11 @@
                     <div class="project-category">
                         <h3 class="category-title">BASIC RESEARCH PROJECTS</h3>
                         <div class="project-list">
+                            <div class="project-item">
+                                <h4 class="project-title">Real-time behavior tracking of planaria</h4>
+                                <p class="project-description">A single planarian flatworm, tracked continuously from an overhead camera. A YOLO-based tracker and behavior model label its location, speed, and behavior (gliding, resting, turning, contracted) in near-real-time. The rig streams live and the tracking plot updates automatically. <a href="https://david-j-cox.github.io/planarian-live/" class="cyber-link" target="_blank" rel="noopener">Watch the live rig &rarr;</a></p>
+                            </div>
+
                             <div class="project-item">
                                 <h4 class="project-title">How might vector embeddings be useful in behavior analysis?</h4>
                                 <p class="project-description">Vector embeddings are a potentially powerful quantitative description of verbal behavior. How might we use this to do things like shape human verbal behavior, model the evolution of verbal communities, and understand gaps in our research literature?</p>

--- a/publications.html
+++ b/publications.html
@@ -35,6 +35,7 @@
                 <li><a href="projects.html" class="nav-link">CURRENT PROJECTS</a></li>
                 <li><a href="publications.html" class="nav-link active">PUBLICATIONS</a></li>
                 <li><a href="books.html" class="nav-link">BOOKS &amp; COURSE COMPANIONS</a></li>
+                <li><a href="https://david-j-cox.github.io/planarian-live/" class="nav-link" target="_blank" rel="noopener"><span style="color:#39ff14;">&#9679;</span> LIVE RIG</a></li>
             </ul>
         </nav>
 


### PR DESCRIPTION
Adds a connection from the lab site to the live planarian tracking page (https://david-j-cox.github.io/planarian-live/).

- **Nav link** `● LIVE RIG` (green live dot) on all five pages (home, about, projects, publications, books), opens the live rig in a new tab.
- **Current Projects card**: "Real-time behavior tracking of planaria" under Basic Research, with a "Watch the live rig →" link.

Only the 5 HTML files are touched. Styled with existing theme classes (nav-link / project-item / cyber-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)