### PR TITLE
Reframe planarian project: Quantifying temporally extended behavioral repertoires

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -51,11 +51,6 @@
                         <h3 class="category-title">BASIC RESEARCH PROJECTS</h3>
                         <div class="project-list">
                             <div class="project-item">
-                                <h4 class="project-title">Real-time behavior tracking of planaria</h4>
-                                <p class="project-description">A single planarian flatworm, tracked continuously from an overhead camera. A YOLO-based tracker and behavior model label its location, speed, and behavior (gliding, resting, turning, contracted) in near-real-time. The rig streams live and the tracking plot updates automatically. <a href="https://david-j-cox.github.io/planarian-live/" class="cyber-link" target="_blank" rel="noopener">Watch the live rig &rarr;</a></p>
-                            </div>
-
-                            <div class="project-item">
                                 <h4 class="project-title">How might vector embeddings be useful in behavior analysis?</h4>
                                 <p class="project-description">Vector embeddings are a potentially powerful quantitative description of verbal behavior. How might we use this to do things like shape human verbal behavior, model the evolution of verbal communities, and understand gaps in our research literature?</p>
                             </div>
@@ -80,6 +75,11 @@
                     <div class="project-category">
                         <h3 class="category-title">TRANSLATIONAL RESEARCH PROJECTS</h3>
                         <div class="project-list">
+                            <div class="project-item">
+                                <h4 class="project-title">Quantifying temporally extended behavioral repertoires</h4>
+                                <p class="project-description">A significant challenge to extending the reach of behavior science is developing a robust understanding of behavioral repertoires, how they develop, how various operant classes are interconnected, and how experiences interact over time. <a href="https://david-j-cox.github.io/planarian-live/" class="cyber-link" target="_blank" rel="noopener">Watch the live planarian rig &rarr;</a></p>
+                            </div>
+
                             <div class="project-item">
                                 <h4 class="project-title">Using behavioral economics to describe and predict ethical decision-making</h4>
                                 <p class="project-description">Though this sounds straightforward, it's anything but. Most work here requires novel methodological approaches that stay true to the underlying behavioral economics literature while carrying face validity with non-laboratory ethical decision-making. But we welcome the challenge.</p>


### PR DESCRIPTION
Per feedback, moves the planarian live-rig project from Basic Research to **Translational Research**, with a new title and description.

- Title: *Quantifying temporally extended behavioral repertoires*
- Description framed around behavioral repertoires, their development, operant-class interconnection, and how experiences interact over time.
- Keeps the obvious live-rig link ("Watch the live planarian rig →").

Only projects.html changed. The nav `LIVE RIG` link from #35 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)