### PR TITLE
AO coverage grid (processes/phenomena x AO approaches)

### DIFF
--- a/ao-grid-render.js
+++ b/ao-grid-render.js
@@ -1,0 +1,61 @@
+/* Renders the AO coverage grid into #ao-grid from window.AOGRID. */
+(function () {
+  const D = window.AOGRID;
+  const mount = document.getElementById('ao-grid');
+  if (!D || !mount) return;
+
+  const labOf = c => D.lab[c] || [];
+  const stateOf = (row, col) => {
+    const l = labOf(col);
+    const isLab = l === '*' || (Array.isArray(l) && l.includes(row));
+    const isField = (D.field[col] || []).includes(row);
+    if (isLab && isField) return 'both';
+    if (isLab) return 'lab';
+    if (isField) return 'field';
+    return 'open';
+  };
+  const rowLabel = {}; D.groups.forEach(g => g.rows.forEach(r => rowLabel[r[0]] = r[1]));
+  const colLabel = Object.fromEntries(D.cols.map(c => [c.id, c.label]));
+
+  const grid = document.createElement('div');
+  grid.className = 'aogrid';
+  grid.style.gridTemplateColumns = `minmax(210px, 1.7fr) repeat(${D.cols.length}, 1fr)`;
+
+  const cell = (cls, html) => { const d = document.createElement('div'); d.className = cls; if (html != null) d.innerHTML = html; return d; };
+
+  // header
+  grid.appendChild(cell('aoh corner', ''));
+  D.cols.forEach(c => grid.appendChild(cell('aoh col', c.label)));
+
+  D.groups.forEach(g => {
+    const gh = cell('aogroup', g.label); gh.style.gridColumn = '1 / -1'; grid.appendChild(gh);
+    g.rows.forEach(([rid, rlabel]) => {
+      grid.appendChild(cell('aorow', rlabel));
+      D.cols.forEach(c => {
+        const st = stateOf(rid, c.id);
+        const dc = cell('aocell ' + st, '');
+        dc.dataset.row = rid; dc.dataset.col = c.id; dc.dataset.state = st;
+        grid.appendChild(dc);
+      });
+    });
+  });
+  mount.appendChild(grid);
+
+  // tooltip
+  const tip = document.createElement('div'); tip.id = 'aogrid-tip'; document.body.appendChild(tip);
+  const STATE = { lab: "Our lab's AO", field: "Another group's AO of this approach", both: "Our lab's AO and another group's", open: 'No AO of this approach yet' };
+  grid.querySelectorAll('.aocell').forEach(dc => {
+    dc.addEventListener('mousemove', ev => {
+      const note = D.notes[dc.dataset.row + '|' + dc.dataset.col];
+      tip.innerHTML = `<b>${rowLabel[dc.dataset.row]}</b><span class="ap">${colLabel[dc.dataset.col]}</span>`
+        + `<span class="st st-${dc.dataset.state}">${STATE[dc.dataset.state]}</span>`
+        + (note ? `<span class="nt">${note}</span>` : '');
+      tip.style.display = 'block';
+      let x = ev.clientX + 14, y = ev.clientY + 14; const r = tip.getBoundingClientRect();
+      if (x + r.width > innerWidth - 10) x = ev.clientX - r.width - 14;
+      if (y + r.height > innerHeight - 10) y = ev.clientY - r.height - 14;
+      tip.style.left = x + 'px'; tip.style.top = y + 'px';
+    });
+    dc.addEventListener('mouseleave', () => tip.style.display = 'none');
+  });
+})();

--- a/ao-grid.css
+++ b/ao-grid.css
@@ -1,0 +1,38 @@
+/* AO coverage grid: phenomena (rows) x approaches (cols). */
+.aogrid{display:grid;gap:3px;max-width:880px;margin:1.2rem 0 0;font-size:.82rem}
+.aogrid .aoh{font-weight:600;color:var(--muted);padding:0 .3rem .5rem;align-self:end}
+.aogrid .aoh.col{text-align:center;font-size:.74rem;line-height:1.2;color:var(--ink)}
+.aogrid .aogroup{font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;color:var(--accent2);
+  font-weight:700;padding:.9rem .2rem .35rem;border-bottom:1px solid var(--line)}
+.aogrid .aorow{color:var(--ink);padding:.42rem .5rem .42rem 0;line-height:1.25;display:flex;align-items:center}
+.aogrid .aocell{min-height:30px;border-radius:5px;cursor:default;transition:transform .08s, outline-color .08s;
+  outline:1px solid transparent}
+.aogrid .aocell:hover{transform:scale(1.06);outline-color:var(--ink)}
+.aogrid .aocell.open{background:rgba(108,197,255,.05);border:1px dashed var(--line)}
+.aogrid .aocell.field{background:rgba(108,197,255,.42)}   /* broader field = blue/accent */
+.aogrid .aocell.lab{background:rgba(169,139,255,.6)}      /* our lab = purple/accent2 */
+.aogrid .aocell.both{background:linear-gradient(135deg, rgba(169,139,255,.6) 0 50%, rgba(108,197,255,.42) 50% 100%)} /* both */
+
+.ao-legend{display:flex;flex-wrap:wrap;gap:1.1rem;align-items:center;margin:.4rem 0 0;font-size:.8rem;color:var(--muted)}
+.ao-legend .key{display:inline-flex;align-items:center;gap:.45rem}
+.ao-legend .sw{width:15px;height:15px;border-radius:4px;display:inline-block}
+.ao-legend .sw.lab{background:rgba(169,139,255,.6)}
+.ao-legend .sw.field{background:rgba(108,197,255,.42)}
+.ao-legend .sw.both{background:linear-gradient(135deg, rgba(169,139,255,.6) 0 50%, rgba(108,197,255,.42) 50% 100%)}
+.ao-legend .sw.open{background:rgba(108,197,255,.05);border:1px dashed var(--line)}
+
+#aogrid-tip{position:fixed;z-index:60;pointer-events:none;display:none;max-width:300px;
+  background:var(--panel,#161b27);border:1px solid var(--line);border-radius:9px;padding:.55rem .7rem;
+  font-size:.82rem;box-shadow:0 8px 28px rgba(0,0,0,.5)}
+#aogrid-tip b{color:var(--ink);display:block;margin-bottom:.1rem}
+#aogrid-tip .ap{color:var(--muted);font-size:.74rem;display:block}
+#aogrid-tip .st{display:inline-block;margin-top:.4rem;font-size:.72rem;font-weight:600}
+#aogrid-tip .st-lab{color:#c3b0ff}
+#aogrid-tip .st-field{color:var(--accent)}
+#aogrid-tip .st-open{color:var(--faint)}
+#aogrid-tip .nt{display:block;margin-top:.4rem;color:var(--muted);font-size:.75rem;line-height:1.4}
+
+@media (max-width:640px){
+  .aogrid{font-size:.74rem}
+  .aogrid .aoh.col{font-size:.64rem}
+}

--- a/ao-grid.js
+++ b/ao-grid.js
@@ -1,0 +1,137 @@
+/* Coverage grid for the artificial-organisms page.
+   rows = behavioral processes / phenomena; cols = artificial-organism approaches.
+   The principles are all long established; the grid asks only who has reproduced
+   each one with THAT SPECIFIC AO approach.
+   A cell is 'lab' (our AO does it), 'field' (another research group's AO of the
+   same approach does it), 'both', or open (no AO of this approach has yet).
+
+   Sources: integrated-principles = the molecular-dynamics-algorithm-ao repo (only
+   ours exists). MPR = mpr-aos (ours is the only MPR AO). ETBD = our etbd-aos plus
+   McDowell and colleagues' ETBD AOs (field). Q-learning = our q-learning-aos plus
+   other groups' RL/Q-learning agent implementations (field); several need augmented
+   variants (latent-cause or distributional RL), noted on hover.
+*/
+window.AOGRID = {
+  cols: [
+    { id: 'qlearning', label: 'Q-learning' },
+    { id: 'mpr', label: 'MPR' },
+    { id: 'etbd', label: 'ETBD' },
+    { id: 'integrated', label: 'Integrated-principles' },
+  ],
+  groups: [
+    { label: 'Respondent', rows: [
+      ['resp_acq', 'Acquisition'],
+      ['resp_ext', 'Extinction'],
+      ['spont', 'Spontaneous recovery'],
+      ['stimgen', 'Stimulus generalization'],
+      ['peakshift', 'Generalization gradient & peak shift'],
+      ['discrim', 'Discrimination'],
+      ['blocking', 'Blocking'],
+      ['overshadow', 'Overshadowing'],
+      ['renewal', 'Renewal (ABA)'],
+      ['reacq', 'Rapid reacquisition'],
+      ['second_order', 'Second-order conditioning'],
+      ['cond_inhib', 'Conditioned inhibition'],
+    ]},
+    { label: 'Operant', rows: [
+      ['op_acq', 'Acquisition'],
+      ['op_ext', 'Extinction'],
+      ['schedules', 'FR / VR / FI / VI schedule signatures'],
+      ['pree', 'Partial-reinforcement extinction effect'],
+      ['threeterm', 'Three-term stimulus control'],
+      ['matching', 'Matching (concurrent + concatenated GML)'],
+      ['momentum', 'Behavioral momentum'],
+      ['contrast', 'Behavioral contrast'],
+      ['punishment', 'Punishment'],
+      ['avoidance', 'Avoidance / negative reinforcement'],
+      ['reinstatement', 'Reinstatement'],
+      ['timing', 'Interval timing'],
+      ['vigor', 'Vigor / response rate & bout structure'],
+    ]},
+    { label: 'Choice, dynamics, & quantitative laws', rows: [
+      ['risk', 'Risk-sensitive foraging / energy-budget rule'],
+      ['resurgence', 'Resurgence'],
+      ['rpasym', 'Reinforcement–punishment asymmetry'],
+      ['skew', 'Higher-moment (skew) effects'],
+      ['single_alt', "Single-alternative response rate (Herrnstein's hyperbola)"],
+      ['magnitude', 'Reinforcer magnitude effects'],
+      ['discounting', 'Delay discounting / impulsive choice'],
+      ['prob_disc', 'Probability discounting'],
+      ['variability', 'Behavioral variability'],
+      ['choice_dyn', 'Choice dynamics / preference tracking'],
+      ['demand', 'Demand / behavioral economics (unit price)'],
+      ['foraging', 'Optimal foraging / patch-leaving (MVT)'],
+    ]},
+  ],
+  // lab[col] = '*' (all rows) or [rowId, ...]. A row in both lab and field shows as 'both'.
+  lab: {
+    // molecular-dynamics-algorithm-ao repo audit
+    integrated: ['resp_acq', 'resp_ext', 'spont', 'stimgen', 'peakshift', 'discrim', 'blocking',
+      'overshadow', 'renewal', 'reacq', 'op_acq', 'op_ext', 'schedules', 'pree', 'threeterm',
+      'matching', 'momentum', 'contrast', 'punishment', 'risk', 'resurgence', 'rpasym', 'skew',
+      'magnitude', 'discounting', 'prob_disc', 'demand', 'timing', 'foraging', 'vigor'],
+    qlearning: ['matching', 'op_acq', 'op_ext', 'resurgence', 'choice_dyn'],
+    mpr: ['single_alt', 'matching', 'choice_dyn'],
+    etbd: ['matching'],
+  },
+  // field[col] = [rowId, ...] (another research group's AO of this approach has demonstrated it)
+  field: {
+    qlearning: ['resp_acq', 'resp_ext', 'spont', 'stimgen', 'discrim', 'blocking', 'overshadow',
+      'renewal', 'reacq', 'op_acq', 'op_ext', 'pree', 'threeterm', 'matching', 'punishment',
+      'rpasym', 'single_alt', 'magnitude', 'discounting', 'risk', 'choice_dyn',
+      'reinstatement', 'avoidance', 'timing', 'vigor', 'second_order', 'cond_inhib'],
+    mpr: [],
+    etbd: ['op_acq', 'op_ext', 'matching', 'punishment', 'rpasym', 'resurgence',
+      'single_alt', 'magnitude', 'discounting', 'variability', 'choice_dyn', 'reinstatement', 'vigor'],
+  },
+  // notes[rowId|colId] shown on hover
+  notes: {
+    // Q-learning (lab repo)
+    'matching|qlearning': 'q-learning-aos, verified: GML on concurrent VI VI (a ≈ 0.63, R² ≈ 0.999). Matching is a property of melioration (softmax), not maximization (greedy responds ~50/50).',
+    'op_acq|qlearning': 'q-learning-aos: allocation rises from indifference toward the matching equilibrium as values are learned (run_acquisition_demo).',
+    'op_ext|qlearning': 'q-learning-aos: target value decays and allocation falls back toward indifference. Caveat: gamma=0 myopic decay (the "unlearning" mechanism the field flags as phenomenologically wrong).',
+    'choice_dyn|qlearning': 'q-learning-aos: reversal learning; allocation tracks the reversal after a lag (run_reversal_demo).',
+    'resurgence|qlearning': 'q-learning-aos reproduces resurgence in a 3-phase design. Notable: the field has no dedicated RL model of resurgence (Resurgence-as-Choice is behavior-analytic), so this is closer to a field-first than a replication.',
+    'rpasym|qlearning': 'Asymmetric +/- prediction-error scaling; distributional RL predicts diverse optimistic/pessimistic channels, confirmed in dopamine (Dabney et al., 2020, Nature).',
+    'discounting|qlearning': 'Plain TD discounts exponentially; hyperbolic discounting is recovered only with a distribution of γ micro-agents (Kurth-Nelson & Redish, 2009). A recognized misfit, then a fix.',
+    'spont|qlearning': 'Not reproduced by plain TD (unlearning cannot return a CR); recovered by latent-cause inference (Gershman, Blei & Niv, 2010).',
+    'renewal|qlearning': 'ABA renewal needs state-classification / latent-cause RL; the clearest "plain TD fails" case (Redish et al., 2007).',
+    'reinstatement|qlearning': 'Reinstatement of an extinguished response by unsignaled reinforcer exposure; latent-state RL (Redish et al., 2007; Gershman et al., 2010).',
+    'avoidance|qlearning': 'Active avoidance / negative reinforcement via actor-critic RL, resolving two-factor theory (Maia, 2010).',
+    'timing|qlearning': 'CR / interval-timing topography via TD with microstimuli (Ludvig, Sutton & Kehoe, 2008).',
+    'vigor|qlearning': 'Free-operant response rate and bout-and-pause microstructure (Niv et al., 2007 average-reward vigor; Yamada & Kanemura, 2020).',
+    'second_order|qlearning': 'Second-order conditioning reproduced by plain TD (Sutton & Barto, 1990).',
+    'cond_inhib|qlearning': 'Conditioned inhibition via TD with a nonnegativity constraint (Sutton & Barto, 1990).',
+    // MPR (lab repo)
+    'single_alt|mpr': "mpr-aos: single VR/VI target rates conform to McDowell's generalized hyperbola (VR R²=1.00, VI R²=0.99) — Herrnstein's single-alternative hyperbola (manuscript, Figs 2 & 4).",
+    'single_alt|integrated': 'Open for the integrated organism: it builds FR/VR/FI/VI rate signatures, not the Herrnstein single-alternative hyperbola (a deliberate scope choice).',
+    'matching|mpr': "mpr-aos: concurrent VR/VI allocation fit by Baum's generalized matching law (R²=0.95/0.96), with undermatching (manuscript, Figs 6 & 8).",
+    'choice_dyn|mpr': 'mpr-aos: preference tracks relative reinforcement via per-alternative coupling with a changeover delay; includes an MPR + Q-learning hybrid (manuscript, Figs 6-9).',
+    'schedules|mpr': 'Open as an AO: our mpr-aos ran only the molar VR/VI rate functions, not the FI-scallop / FR-break-run microstructure, and no other MPR artificial organism exists.',
+    // ETBD (literature review)
+    'matching|etbd': 'Established for ETBD in the field: concurrent RI RI AOs fit the GML at pVAF 0.97-1.00 with undermatching emergent (McDowell, Caron, Kulubekova & Berg, 2008, JEAB). Our etbd-aos reproduces it (a ≈ 0.60).',
+    'op_acq|etbd': 'Virtual organisms acquire responding on RI schedules from a random population (McDowell, 2004, JEAB).',
+    'op_ext|etbd': 'Extinction by mutating behavior out of the reinforced class (Kulubekova & McDowell, 2008).',
+    'punishment|etbd': 'Punishment as mutation out of the punished class; suppresses the punished alternative (McDowell & Klapes, 2019, JEAB).',
+    'rpasym|etbd': 'Punishment efficacy is asymmetric by reinforcement context (McDowell & Klapes, 2019, JEAB).',
+    'resurgence|etbd': 'AOs reproduce target-response recurrence when alternative reinforcement is downshifted (~86.7% vs ~87.5% in live animals; Falligant, Klapes & Hagopian, 2022).',
+    'reinstatement|etbd': 'Response-dependent reinstatement of an extinguished response reproduced by ETBD AOs (McDowell group, 2025).',
+    'single_alt|etbd': "Single RI schedules emergently produce Herrnstein's hyperbola (McDowell, 2004, JEAB).",
+    'magnitude|etbd': 'Response rate is a joint function of reinforcement rate and magnitude (McDowell, 2021, JEAB).',
+    'discounting|etbd': 'AOs produce hyperbolic delay-discounting curves matching pigeon, rat, and human data (Higginbotham et al., 2025, Perspectives on Behavior Science).',
+    'variability|etbd': 'Variability scales with the mutation rate and reinforcement (Popa & McDowell, 2016, JEAB). Not variability reinforced as an operant.',
+    'choice_dyn|etbd': 'AOs track local shifts in reinforcer ratios across successive reinforcers (Kulubekova & McDowell, 2013, JEAB).',
+    'vigor|etbd': 'Log-survivor inter-response-time bout structure under interval schedules (Kulubekova & McDowell, 2008).',
+    'schedules|etbd': 'Left open for ETBD: it uses RI/RR analogs and reproduces rates and concurrent preference, but not the FI-scallop / FR-break-and-run molecular signatures.',
+    // Integrated (molecular-dynamics repo)
+    'magnitude|integrated': 'Demonstrated as the amount term of the concatenated matching law (allocation tracks relative amount, a ≈ 0.97; emergent). A standalone single-operant magnitude effect remains a gap.',
+    'discounting|integrated': 'Demonstrated as the delay term of the concatenated matching law (hyperbolic). The smaller-sooner vs larger-later self-control procedure remains a gap.',
+    'prob_disc|integrated': 'Probability discounting as the probability term of the concatenated matching law (emergent; exp013).',
+    'demand|integrated': 'Demand / unit price: consumption falls as response cost rises (emergent; exp016).',
+    'timing|integrated': 'Interval timing via a pluggable SET/BeT/LeT module, plus temporal stimulus control / food anticipation (exp017, exp064).',
+    'foraging|integrated': 'Optimal foraging / patch-leaving (marginal value theorem) and the Charnov functional response (exp020, exp021; emergent).',
+    'vigor|integrated': 'Free-operant response rates and the post-reinforcement pause (FR > VR) under schedules (exp018).',
+    'resurgence|integrated': 'Resurgence as model mimicry; part of the resurgence study (four processes, one phenomenon).',
+    'risk|integrated': 'Risk-sensitive foraging follows from the energy-budget rule (Caraco, 1980; Stephens & Krebs, 1986).',
+  },
+};

--- a/area-artificial-organisms.html
+++ b/area-artificial-organisms.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="site.css">
+    <link rel="stylesheet" href="ao-grid.css">
 </head>
 <body>
     <div class="cyberpunk-container">
@@ -43,9 +44,23 @@
             </section>
 
             <div class="about-card">
-                <p class="cyber-text" style="font-size:1.02rem;color:var(--ink)">&ldquo;What I cannot create, I do not understand.&rdquo; One way we test how behavioral principles integrate is to build them. We construct artificial organisms that combine principles and processes under a set of assumptions, then watch what reproduces real behavior and where things break down. Where the lab studies how processes interact in living organisms, this program asks a related question: can the same processes, assembled from first principles, generate the same patterns?</p>
+                <p class="cyber-text" style="font-size:1.02rem;color:var(--ink)">&ldquo;What I cannot create, I do not understand&rdquo; (Richard Feynman). One way we test how behavioral principles integrate is to build them. We construct artificial organisms that combine principles and processes under a set of assumptions, then watch what reproduces real behavior and where things break down. Where the lab studies how processes interact in living organisms, this program asks a related question: can the same processes, assembled from first principles, generate the same patterns?</p>
                 <div class="publication-links" style="margin-top:1.4rem"><a href="ao-lab-update.html" class="cyber-button" style="font-size:.85rem;padding:.7rem 1.2rem">Open the Lab Update &rarr;</a></div>
             </div>
+
+            <section class="ao-grid-sec" style="margin:34px 0 10px">
+                <h3 class="cyber-h3" style="text-align:left;margin-bottom:.6rem">What each approach reproduces</h3>
+                <p class="cyber-text" style="text-align:left;max-width:760px">Every approach to building an artificial organism is an attempt to regenerate behavior we already measure. The principles themselves are long established, so the grid asks only one thing: who has reproduced each one with that specific AO approach? Each row is a behavioral process or phenomenon, each column is an AO approach. Purple means our lab's AO has done it; blue means another research group's AO of the same approach has; a split cell means both; an empty cell means no AO of that approach has yet. Hover a cell for the details.</p>
+                <div class="ao-legend">
+                    <span class="key"><span class="sw lab"></span> Our lab's AO</span>
+                    <span class="key"><span class="sw field"></span> Another group's AO</span>
+                    <span class="key"><span class="sw both"></span> Both</span>
+                    <span class="key"><span class="sw open"></span> No AO yet</span>
+                </div>
+                <div id="ao-grid"></div>
+                <p class="cyber-text" style="text-align:left;font-size:.82rem;color:var(--faint);margin-top:1.1rem;max-width:760px">Every column is sourced: the integrated-principles column from the molecular-dynamics repo, and the ETBD, MPR, and Q-learning columns from each lab repo (purple) plus a review of that approach's published literature (blue). Some reinforcement-learning cells hold only with augmented variants (latent-cause or distributional RL); hover for the specifics.</p>
+            </section>
+
             <div class="project-category">
                 <h3 class="category-title">Artificial organisms <span style="color:var(--faint);font-weight:400">(2)</span></h3>
                 <div class="project-list">
@@ -67,5 +82,7 @@
             </div>
         </footer>
     </div>
+<script src="ao-grid.js"></script>
+<script src="ao-grid-render.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds an interactive coverage grid to the (previously bare) **Artificial organisms** area page (`area-artificial-organisms.html`).

## What it shows
Rows = behavioral processes / phenomena (37, grouped respondent / operant / choice & dynamics). Columns = the AO approaches: **Q-learning, MPR, ETBD, integrated-principles**. The principles are all long established, so each cell asks only *who has reproduced it with that specific AO*:
- **purple** = our lab's AO
- **blue** = another research group's AO of the same approach
- **split** = both
- **empty** = no AO of that approach yet (the collaboration frontier)

Hover any cell for the specific demonstration and citation.

## Sourcing
- **integrated-principles** — audit of the `molecular-dynamics-algorithm-ao` repo (only ours exists → purple).
- **MPR** — `mpr-aos` (ours is the only MPR AO → all purple: single-alternative hyperbola, matching, choice dynamics).
- **ETBD** — our `etbd-aos` (matching) + a literature review of McDowell and colleagues' ETBD AOs (blue).
- **Q-learning** — our `q-learning-aos` (incl. a resurgence demo that is a field-first) + other groups' RL/Q-learning agent implementations (blue), several flagged "needs augmented variant" on hover.

Files: `ao-grid.js` (data), `ao-grid-render.js`, `ao-grid.css`. Feynman quote attributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)