### PR TITLE
AO grid: split Molecular dynamics and Dynamical systems columns

### DIFF
--- a/ao-grid.css
+++ b/ao-grid.css
@@ -1,5 +1,6 @@
 /* AO coverage grid: phenomena (rows) x approaches (cols). */
-.aogrid{display:grid;gap:3px;max-width:880px;margin:1.2rem 0 0;font-size:.82rem}
+#ao-grid{overflow-x:auto;max-width:100%}
+.aogrid{display:grid;gap:3px;max-width:1080px;min-width:860px;margin:1.2rem 0 0;font-size:.82rem}
 .aogrid .aoh{font-weight:600;color:var(--muted);padding:0 .3rem .5rem;align-self:end}
 .aogrid .aoh.col{text-align:center;font-size:.74rem;line-height:1.2;color:var(--ink)}
 .aogrid .aogroup{font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;color:var(--accent2);

--- a/ao-grid.js
+++ b/ao-grid.js
@@ -16,7 +16,8 @@ window.AOGRID = {
     { id: 'qlearning', label: 'Q-learning' },
     { id: 'mpr', label: 'MPR' },
     { id: 'etbd', label: 'ETBD' },
-    { id: 'integrated', label: 'Integrated-principles' },
+    { id: 'integrated', label: 'Molecular dynamics' },
+    { id: 'dynsys', label: 'Dynamical systems' },
   ],
   groups: [
     { label: 'Respondent', rows: [
@@ -62,6 +63,12 @@ window.AOGRID = {
       ['demand', 'Demand / behavioral economics (unit price)'],
       ['foraging', 'Optimal foraging / patch-leaving (MVT)'],
     ]},
+    { label: 'Dynamical-systems signatures', rows: [
+      ['behavior_networks', 'Behavior networks (multi-response coupling)'],
+      ['attractor_dynamics', 'Attractor / disequilibrium dynamics'],
+      ['oscillation', 'Oscillatory return to equilibrium (Brunt–Väisälä)'],
+      ['hysteresis', 'Path dependence / hysteresis'],
+    ]},
   ],
   // lab[col] = '*' (all rows) or [rowId, ...]. A row in both lab and field shows as 'both'.
   lab: {
@@ -73,6 +80,9 @@ window.AOGRID = {
     qlearning: ['matching', 'op_acq', 'op_ext', 'resurgence', 'choice_dyn'],
     mpr: ['single_alt', 'matching', 'choice_dyn'],
     etbd: ['matching'],
+    // integrating-behavioral-processes (Cox, 2026) + measuring-behavior-trajectories (N=60)
+    dynsys: ['matching', 'choice_dyn', 'op_ext', 'momentum', 'foraging',
+      'behavior_networks', 'attractor_dynamics', 'oscillation', 'hysteresis'],
   },
   // field[col] = [rowId, ...] (another research group's AO of this approach has demonstrated it)
   field: {
@@ -83,6 +93,8 @@ window.AOGRID = {
     mpr: [],
     etbd: ['op_acq', 'op_ext', 'matching', 'punishment', 'rpasym', 'resurgence',
       'single_alt', 'magnitude', 'discounting', 'variability', 'choice_dyn', 'reinstatement', 'vigor'],
+    // ours is the only dynamical-systems behavioral AO; no other-group field layer
+    dynsys: [],
   },
   // notes[rowId|colId] shown on hover
   notes: {
@@ -133,6 +145,16 @@ window.AOGRID = {
     'vigor|integrated': 'Free-operant response rates and the post-reinforcement pause (FR > VR) under schedules (exp018).',
     'resurgence|integrated': 'Resurgence as model mimicry; part of the resurgence study (four processes, one phenomenon).',
     'risk|integrated': 'Risk-sensitive foraging follows from the energy-budget rule (Caraco, 1980; Stephens & Krebs, 1986).',
+    // Dynamical systems (Cox, 2026)
+    'matching|dynsys': 'Matching emerges as the equilibrium of the field (allocation converges to Vᵢ/ΣVⱼ), shown as a vector field flowing to the y=x equilibrium; also fit to N=60 human data.',
+    'choice_dyn|dynsys': 'Preference re-tracks at each reversal (ABAB), tracking speed set by inertia; adaptation lags quantified in N=60 humans (measuring-behavior-trajectories).',
+    'op_ext|dynsys': 'Return-to-baseline: response rate decays exponentially when reinforcement is removed, decay rate set by behavioral-momentum history (Fig 6).',
+    'momentum|dynsys': 'Behavioral mass = resistance to change; mass grows with cumulative reinforcement, so higher-mass responses change and extinguish more slowly (Eqs 6-7).',
+    'foraging|dynsys': 'Optimal foraging / marginal value theorem fit to human allocation; 25/60 within ±5% of the computed optimum (measuring-behavior-trajectories, Fig 5).',
+    'behavior_networks|dynsys': 'Displacing one response propagates to others through a coupling matrix wᵢⱼ; simulated as a 5-response coupled network. The headline "behavior networks" construct (Eqs 11-13).',
+    'attractor_dynamics|dynsys': 'The matching surface is a restoring attractor: a disequilibrium force field F = −∇Φ pulls behavior back to equilibrium in a curved potential valley (Eqs 4-5, 10).',
+    'oscillation|dynsys': 'Displaced behavior oscillates back to equilibrium at the Brunt–Väisälä frequency ω², scaled by local reinforcer density. The namesake mechanism (Eqs 8-9).',
+    'hysteresis|dynsys': 'P(choose A) vs unobserved advantage traces a hysteresis loop between rising and falling phases (it collapses against local reinforcement rate); N=60 humans (Fig 4).',
   },
   // refs[rowId|colId] = [citation, ...] -- the AO implementations behind a cell.
   // Rendered as Google Scholar links on click. Field cells = other groups' AOs.
@@ -179,5 +201,15 @@ window.AOGRID = {
     'choice_dyn|etbd': ['Kulubekova & McDowell (2013). Latching of behavior dynamics to changing reinforcer ratios. JEAB.'],
     'reinstatement|etbd': ['McDowell and colleagues (2025). A computational model of response-dependent reinstatement.'],
     'vigor|etbd': ['Kulubekova & McDowell (2008). Behavioural Processes.'],
+    // Dynamical systems -- our work (Cox, 2026)
+    'matching|dynsys': ['Cox, D. J. (2026). Toward a Dynamical Systems Account of Behavior Networks.'],
+    'choice_dyn|dynsys': ['Cox, D. J. (2026). Toward a Dynamical Systems Account of Behavior Networks.', 'Cox, D. J. (2026). Measuring behavior trajectories (N=60 phase-transition dynamics).'],
+    'op_ext|dynsys': ['Cox, D. J. (2026). Toward a Dynamical Systems Account of Behavior Networks.'],
+    'momentum|dynsys': ['Cox, D. J. (2026). Toward a Dynamical Systems Account of Behavior Networks.'],
+    'foraging|dynsys': ['Cox, D. J. (2026). Measuring behavior trajectories (N=60 phase-transition dynamics).'],
+    'behavior_networks|dynsys': ['Cox, D. J. (2026). Toward a Dynamical Systems Account of Behavior Networks.'],
+    'attractor_dynamics|dynsys': ['Cox, D. J. (2026). Toward a Dynamical Systems Account of Behavior Networks.'],
+    'oscillation|dynsys': ['Cox, D. J. (2026). Toward a Dynamical Systems Account of Behavior Networks.'],
+    'hysteresis|dynsys': ['Cox, D. J. (2026). Measuring behavior trajectories (N=60 phase-transition dynamics).'],
   },
 };

--- a/area-artificial-organisms.html
+++ b/area-artificial-organisms.html
@@ -58,7 +58,7 @@
                     <span class="key"><span class="sw open"></span> Not yet</span>
                 </div>
                 <div id="ao-grid"></div>
-                <p class="cyber-text" style="text-align:left;font-size:.82rem;color:var(--faint);margin-top:1.1rem;max-width:760px">Every column is sourced: the integrated-principles column from the molecular-dynamics repo, and the ETBD, MPR, and Q-learning columns from each lab repo (purple) plus a review of that approach's published literature (blue). Some reinforcement-learning cells hold only with augmented variants (latent-cause or distributional RL); hover for the specifics.</p>
+                <p class="cyber-text" style="text-align:left;font-size:.82rem;color:var(--faint);margin-top:1.1rem;max-width:760px">Every column is sourced: the Molecular dynamics and Dynamical systems columns from our own repos (ours are the only such organisms, so no other-researcher layer), and the ETBD, MPR, and Q-learning columns from our lab repos (purple) plus a review of other groups' AOs of that approach (blue). Some reinforcement-learning cells hold only with augmented variants (latent-cause or distributional RL); hover for the specifics.</p>
             </section>
 
             <div class="project-category">


### PR DESCRIPTION
Splits the former 'Integrated-principles' column (which conflated two distinct lines) into two:
- **Molecular dynamics** — the `molecular-dynamics-algorithm-ao` first-principles organism (relabeled; data unchanged).
- **Dynamical systems** — the Brunt-Väisälä / behavior-networks line (Cox, 2026): matching, choice dynamics, extinction, behavioral momentum, optimal foraging, plus a new 'Dynamical-systems signatures' group (behavior networks/coupling, attractor dynamics, Brunt-Väisälä oscillation, hysteresis). No other group has a dynamical-systems behavioral AO, so it is all our-lab.

Sourced from `integrating-behavioral-processes` + `measuring-behavior-trajectories` (N=60). Grid widened to five columns with horizontal scroll on small screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)