### PR TITLE
Methodological-backbone deck: the expanded toolchest (radial)

### DIFF
--- a/area-methodological-backbone.html
+++ b/area-methodological-backbone.html
@@ -9,21 +9,28 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="site.css">
+    <link rel="stylesheet" href="methods.css">
+    <style>
+      .deck{max-width:1000px;margin:0 auto;padding:8px 28px 90px}
+      .deck-hero{padding:26px 0 38px;border-bottom:1px solid var(--line);margin-bottom:44px}
+      .deck .kicker{font-size:.72rem;letter-spacing:.16em;text-transform:uppercase;color:var(--accent);font-weight:600;margin-bottom:.6rem}
+      .deck-hero h1{font-size:2.6rem;line-height:1.08;font-weight:700;margin:0 0 1rem;letter-spacing:-.02em}
+      .deck-hero p{font-size:1.12rem;color:var(--muted);line-height:1.65;max-width:740px;margin:0}
+      .deck-sec{margin:0 0 60px}
+      .deck-sec h2{font-size:1.7rem;font-weight:700;margin:0 0 1rem;letter-spacing:-.01em}
+      .deck-sec>p{color:var(--muted);font-size:1.04rem;line-height:1.72;max-width:740px;margin:0 0 1.1rem}
+      .map-note{font-size:.82rem;color:var(--faint);margin-top:1rem;max-width:740px}
+      .collab .cta-big{display:inline-block;margin-top:1.1rem;padding:.7rem 1.2rem;border-radius:9px;background:var(--accent);color:#06223a;font-weight:600;text-decoration:none}
+    </style>
 </head>
 <body>
     <div class="cyberpunk-container">
         <header class="cyber-header">
             <div class="header-content">
-                <h1 class="lab-title">
-                    <span class="glitch">BEHAVIORAL DATA SCIENCE</span>
-                    <span class="lab-subtitle">RESEARCH LAB</span>
-                </h1>
-                <div class="pliny-logo"><div class="pliny-container">
-                    <img src="images/Pliny-the-Pigeon.png" alt="Pliny the Pigeon" class="pliny-image">
-                </div></div>
+                <h1 class="lab-title"><span class="glitch">BEHAVIORAL DATA SCIENCE</span><span class="lab-subtitle">RESEARCH LAB</span></h1>
+                <div class="pliny-logo"><div class="pliny-container"><img src="images/Pliny-the-Pigeon.png" alt="Pliny the Pigeon" class="pliny-image"></div></div>
             </div>
         </header>
-
         <nav class="cyber-nav">
             <ul class="nav-list">
                 <li><a href="index.html" class="nav-link">TOPIC MAP</a></li>
@@ -35,130 +42,52 @@
             </ul>
         </nav>
 
-        <main class="cyber-main">
+        <main class="deck">
             <p class="area-back"><a href="index.html">&larr; Back to the topic map</a></p>
-            <section class="page-header" style="text-align:left;border:none;margin-bottom:18px">
-                <div class="area-kicker">Data &middot; science &middot; mathematics</div>
-                <h2 class="cyber-h2" style="text-align:left">Methodological backbone</h2>
+
+            <section class="deck-hero">
+                <div class="kicker">Methodological backbone &middot; a line of research</div>
+                <h1>New questions need new tools.</h1>
+                <p>Behavior analysis has a powerful, time-tested toolkit: single-subject design, visual analysis,
+                   and descriptive statistics. To ask and answer questions the field has not been able to ask
+                   before, we have to reach past it and leverage state-of-the-art technologies and analytic
+                   approaches. This line of work builds and shares those tools, expanding what a behavior analyst
+                   can do.</p>
             </section>
 
-            <div class="about-card">
-                <p class="cyber-text" style="font-size:1.02rem;color:var(--ink)">Running beneath every project is a common methodological spine. This area covers the quantitative, computational, and statistical methods we use to model environment-behavior relations, along with the research methodologies (e.g., measurement, design, and analysis) that let us see interactions in the first place and move findings from one level of analysis to the next.</p>
-                
-            </div>
-            <div class="project-category">
-                <h3 class="category-title">Quantitative, computational &amp; statistical methods <span style="color:var(--faint);font-weight:400">(18)</span></h3>
-                <div class="project-list">
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2026-of-models-vectors-and-matrices-advancing-analyses-of-th">Of models, vectors, and matrices- Advancing analyses of the multiple control of behavior</a></h4>
-                        <p class="project-description">Cox &middot; 2026</p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2026-using-ml-to-analyze-alternating-treatment-graphs">Using ML to analyze alternating treatment graphs</a></h4>
-                        <p class="project-description">Kausch et al &middot; 2026 &middot; <a href="https://doi.org/10.1007/s10864-026-09616-z" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2025-chapter-8-behavioral-data-science">Chapter 8- Behavioral data science</a></h4>
-                        <p class="project-description">Cox &middot; 2025 &middot; <a href="https://doi.org/10.1016/B978-0-443-22358-7.00014-9" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2025-escape-from-static-flatland-how-might-behavior-as-movem">Escape from static flatland- How might behavior as movement be captured in publications</a></h4>
-                        <p class="project-description">Cox &middot; 2025 &middot; <a href="https://doi.org/10.17605/OSF.IO/PW6B8" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2025-getting-more-from-your-ioa-data-alternative-measures-to">Getting more from your IOA data- Alternative measures to total, occurrence, and non-occurrence agreement</a></h4>
-                        <p class="project-description">Cox et al &middot; 2025 &middot; <a href="https://doi.org/10.1002/bin.70031" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2025-sqab-2024-quantitative-frontiers-in-the-analysis-of-beh">SQAB 2024- Quantitative frontiers in the analysis of behavior</a></h4>
-                        <p class="project-description">Sanabria et al &middot; 2025 &middot; <a href="https://doi.org/10.1007/s40614-025-00457-1" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2024-readme-the-code-to-create-the-cover-toc-graphs">README- The code to create the cover &amp; ToC graphs</a></h4>
-                        <p class="project-description">Cox &middot; 2024</p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2024-the-logic-and-code-behind-the-cover-toc-graphs">The logic and code behind the cover &amp; ToC graphs</a></h4>
-                        <p class="project-description">Cox &middot; 2024 &middot; <a href="https://doi.org/10.17605/OSF.IO/B6XUH" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2024-we-live-in-interesting-times-intro-to-the-special-secti">We live in interesting times- Intro to the special section on big data &amp; behavior science</a></h4>
-                        <p class="project-description">Cox &amp; Young &middot; 2024 &middot; <a href="https://doi.org/10.1007/s40614-024-00400-w" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2023-data-recording-and-analysis">Data recording and analysis</a></h4>
-                        <p class="project-description">Cox et al &middot; 2023 &middot; <a href="https://doi.org/10.1016/B978-0-323-99594-8.00009-X" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2023-identifying-trends-in-the-open-access-behavior-analytic">Identifying trends in the open-access behavior analytic literature via computational analyses (I)- Simple descriptions of text</a></h4>
-                        <p class="project-description">Sosine &amp; Cox &middot; 2023 &middot; <a href="https://doi.org/10.1007/s40616-022-00179-4" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2023-statistics-for-aba-practitioners-and-researchers">Statistics for ABA Practitioners and Researchers</a></h4>
-                        <p class="project-description">Cox &amp; Vladescu &middot; 2023</p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2019-the-many-functions-of-quantitative-modeling">The many functions of quantitative modeling</a></h4>
-                        <p class="project-description">Cox &middot; 2019 &middot; <a href="https://doi.org/10.1007/s42113-019-00048-9" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=book-codingforbehavioranalysts">CodingForBehaviorAnalysts</a></h4>
-                        <p class="project-description">Book</p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=book-statistics-for-aba-practitioners-and-researchers">Statistics for ABA Practitioners and Researchers</a></h4>
-                        <p class="project-description">Book</p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=preprint-ml-pigeon-peck-irts-choices">Using machine learning for multiscale, nonlinear dynamical analyses of pigeon peck IRTs and side-entry choices</a></h4>
-                        <p class="project-description">Cox, D. J., Drugan-Eppich, K., &amp; Sanabria, F. &middot; Preprint &middot; <a href="https://doi.org/10.13140/RG.2.2.27835.78880" target="_blank" rel="noopener">Preprint</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=preprint-3-9-million-aba-sessions">Initial description of 3.9 million unique ABA sessions</a></h4>
-                        <p class="project-description">Sosine, J., &amp; Cox, D. J. &middot; Preprint &middot; <a href="https://osf.io/preprints/psyarxiv/pq28y" target="_blank" rel="noopener">Preprint</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=preprint-cluster-analyses-asd">Influence of sample size, feature set, and algorithm on cluster analyses for patients with autism spectrum disorders</a></h4>
-                        <p class="project-description">Cox, D. J., Sosine, J., &amp; Rethink Data Team &middot; Preprint &middot; <a href="https://psyarxiv.com/9k2yv" target="_blank" rel="noopener">Preprint</a></p>
-                    </div>
-                </div>
-            </div>
-            <div class="project-category">
-                <h3 class="category-title">Research Methodologies <span style="color:var(--faint);font-weight:400">(6)</span></h3>
-                <div class="project-list">
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2022-training-staff-to-create-equivalence-based-instruction-">Training staff to create equivalence-based instruction materials in Qualtrics</a></h4>
-                        <p class="project-description">Marano-Frezza et al &middot; 2022 &middot; <a href="https://doi.org/10.1007/s40732-021-00497-4" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2019-a-multidisciplinary-replication-of-upper-s-1974-unsucee">A multidisciplinary replication of Upper's (1974) unsuceesful self-treatment of writer's block</a></h4>
-                        <p class="project-description">Brodhead et al &middot; 2019 &middot; <a href="https://doi.org/10.1007/s40617-018-00290-w" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2018-function-matters-a-review-of-terminological-differences">Function matters- A review of terminological differences in applied and basic clicker training research</a></h4>
-                        <p class="project-description">Dorey &amp; Cox &middot; 2018 &middot; <a href="https://doi.org/10.7717/peerj.5621" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2018-further-comparison-of-5-trial-adjusting-delay-and-proba">Further comparison of 5-trial adjusting delay and probability tasks over a wide range of amounts</a></h4>
-                        <p class="project-description">Miranda et al &middot; 2018 &middot; <a href="https://doi.org/10.1016/j.beproc.2018.08.004" target="_blank" rel="noopener">DOI</a></p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=2016-a-brief-overview-of-within-subject-experimental-design-">A brief overview of within-subject experimental design logic for individuals with ASD</a></h4>
-                        <p class="project-description">Cox &middot; 2016</p>
-                    </div>
-                    <div class="project-item">
-                        <h4 class="project-title"><a href="index.html#paper=preprint-survey-open-science-practices">Survey of open science practices in behavior analysis</a></h4>
-                        <p class="project-description">Jennings, A. M., Breeman, S., Vladescu, J., &amp; Cox, D. J. &middot; Preprint &middot; <a href="https://osf.io/preprints/psyarxiv/pbn8q_v1" target="_blank" rel="noopener">Preprint</a></p>
-                    </div>
-                </div>
-            </div>
+            <section class="deck-sec">
+                <h2>Expanding the repertoire</h2>
+                <p>Each new method is a tool added to the chest, and a new question it lets you ask. We model the
+                   structure of behavior, work at the scale of whole literatures, bring machine learning and modern
+                   statistics to behavioral data, measure behavior in new ways, and package the methods so others
+                   can use them too. The point is not novelty for its own sake; it is reaching questions the
+                   standard toolkit leaves out of range.</p>
+            </section>
+
+            <section class="deck-sec">
+                <h2>The expanded toolchest</h2>
+                <p>The field's traditional methods sit at the center. Each colored spoke is a new capability, and
+                   each project radiates outward along it (oldest nearest the center, newest farthest), so the
+                   repertoire visibly grows. Hover a node to see the paper, click to read it, and click a spoke
+                   label for what that capability lets you ask.</p>
+                <div class="methods-centerpiece"><div class="methods-scroll"><div id="methods-radial"></div></div></div>
+                <p class="map-note">Distance from the center is the year of the work; the spoke color marks the
+                   capability. Nineteen methods papers across two threads (quantitative, computational, and
+                   statistical methods, and research methodologies).</p>
+            </section>
+
+            <section class="deck-sec collab">
+                <h2>The open frontier</h2>
+                <p>The fastest way to ask a new question is to pick up a tool you have not used yet. If you want to
+                   learn how one of these methods works, or to bring one to a question in your own research, we
+                   would like to help. The aim is a field that can ask and answer questions it could not before.</p>
+                <a class="cta-big" href="mailto:cox.david.j@gmail.com?subject=Learning%20a%20new%20method">Learn a new tool with us &rarr;</a>
+            </section>
         </main>
 
-        <footer class="cyber-footer">
-            <div class="footer-content">
-                <p>&copy; 2025 Behavioral Data Science Research Lab</p>
-            </div>
-        </footer>
+        <footer class="cyber-footer"><div class="footer-content"><p>&copy; 2025 Behavioral Data Science Research Lab</p></div></footer>
     </div>
+<script src="data/corpus.js"></script>
+<script src="methods-render.js"></script>
 </body>
 </html>

--- a/methods-render.js
+++ b/methods-render.js
@@ -1,0 +1,97 @@
+/* Renders the "expanded toolchest" radial into #methods-radial from window.CORPUS.
+   Hub = traditional toolkit; each spoke = a capability; each paper = a node
+   radiating outward (oldest nearest the hub, newest farthest). */
+(function () {
+  const wrap = document.getElementById('methods-radial');
+  if (!wrap) return;
+  // Order matters: spokes are placed clockwise from the top, so adjacency follows this list.
+  const CAPS = [
+    { fam: 'Work at scale', color: '#6cc5ff', trad: 'one graph at a time', now: 'whole literatures and large datasets', papers: [
+      { kw: 'we live in interesting times', short: 'Big data intro' },
+      { kw: 'identifying trends in the open-access', short: 'Literature trends' },
+      { kw: 'behavioral data science', short: 'Behavioral data science' }] },
+    { fam: 'Modeling', color: '#a98bff', trad: 'verbal description', now: 'quantitative and computational models', papers: [
+      { kw: 'the many functions of quantitative modeling', short: 'Functions of modeling' },
+      { kw: 'quantitative frontiers in the analysis', short: 'Quantitative frontiers' },
+      { kw: 'of models, vectors, and matrices', short: 'Models & matrices' }] },
+    { fam: 'Machine learning', color: '#ff7a9c', trad: 'hand-scoring graphs', now: 'algorithms that read and score them', papers: [
+      { kw: 'using ml to analyze alternating treatment graphs', short: 'ML for graphs' }] },
+    { fam: 'Statistics', color: '#ffd166', trad: 'visual inspection', now: 'principled inference built for ABA', papers: [
+      { kw: 'statistics for aba practitioners', short: 'Statistics for ABA' }] },
+    { fam: 'Measurement', color: '#5fd6a4', trad: 'count and rate', now: 'movement, richer agreement, adjusting tasks', papers: [
+      { kw: 'further comparison of 5-trial', short: '5-trial tasks' },
+      { kw: 'data recording and analysis', short: 'Data recording' },
+      { kw: 'getting more from your ioa data', short: 'IOA measures' },
+      { kw: 'escape from static flatland', short: 'Behavior as movement' }] },
+    { fam: 'Design', color: '#7ce0e0', trad: 'convention', now: 'explicit single-case logic, replication, functional terms', papers: [
+      { kw: 'within-subject experimental design logic', short: 'Within-subject logic' },
+      { kw: 'function matters', short: 'Function & terms' },
+      { kw: 'multidisciplinary replication of upper', short: 'Upper replication' }] },
+    { fam: 'Reproducible tools', color: '#c3a3ff', trad: 'bespoke and manual', now: 'shared code and templates others reuse', papers: [
+      { kw: 'training staff to create equivalence-based instruction', short: 'EBI in Qualtrics' },
+      { kw: 'the logic and code behind the cover', short: 'Cover/ToC graphs' },
+      { kw: 'readme- the code to create', short: 'Cover graphics code' }] },
+  ];
+  const items = (window.CORPUS && window.CORPUS.items) || [];
+  const find = kw => items.find(it => it.title.toLowerCase().includes(kw));
+  const esc = s => String(s || '').replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+  const linkOf = it => it.doi ? 'https://doi.org/' + it.doi : 'https://scholar.google.com/scholar?q=' + encodeURIComponent(it.title);
+
+  const NS = 'http://www.w3.org/2000/svg';
+  const lines = document.createElementNS(NS, 'svg');
+  lines.setAttribute('class', 'lines'); lines.setAttribute('viewBox', '0 0 1200 1200'); lines.setAttribute('preserveAspectRatio', 'none');
+  wrap.appendChild(lines);
+
+  const C = 600, r0 = 164, rstep = 118, N = CAPS.length;
+  const hub = document.createElement('div'); hub.className = 'hub'; hub.style.left = (C - 98) + 'px'; hub.style.top = (C - 98) + 'px';
+  hub.innerHTML = '<div class="ht">TRADITIONAL TOOLCHEST</div><div class="hs">single-subject design &middot; visual analysis &middot; descriptive statistics</div>';
+  wrap.appendChild(hub);
+
+  const tip = document.createElement('div'); tip.id = 'methods-tip'; document.body.appendChild(tip);
+  const panel = document.createElement('aside'); panel.id = 'methods-panel';
+  panel.innerHTML = '<button class="x" aria-label="Close">&times;</button><div class="b"></div>';
+  document.body.appendChild(panel);
+  panel.querySelector('.x').onclick = () => panel.classList.remove('open');
+  const pb = panel.querySelector('.b');
+  function showTip(ev, html) {
+    tip.innerHTML = html; tip.style.display = 'block';
+    let x = ev.clientX + 14, y = ev.clientY + 14; const r = tip.getBoundingClientRect();
+    if (x + r.width > innerWidth - 10) x = ev.clientX - r.width - 14;
+    if (y + r.height > innerHeight - 10) y = ev.clientY - r.height - 14;
+    tip.style.left = x + 'px'; tip.style.top = y + 'px';
+  }
+  const groups = [];
+  function highlight(i) { groups.forEach((g, k) => g.forEach(e => e.classList.toggle('dim', i != null && k !== i))); }
+
+  CAPS.forEach((c, i) => {
+    const ang = (i * 360 / N - 90) * Math.PI / 180, dx = Math.cos(ang), dy = Math.sin(ang);
+    const ps = c.papers.map(p => ({ ...p, it: find(p.kw) })).filter(p => p.it).sort((a, b) => (a.it.year || 0) - (b.it.year || 0));
+    const maxR = r0 + (ps.length - 1) * rstep, g = [];
+    const ln = document.createElementNS(NS, 'line');
+    ln.setAttribute('x1', C); ln.setAttribute('y1', C); ln.setAttribute('x2', C + maxR * dx); ln.setAttribute('y2', C + maxR * dy);
+    ln.setAttribute('stroke', c.color); ln.setAttribute('stroke-opacity', '.3'); ln.setAttribute('stroke-width', '2'); lines.appendChild(ln); g.push(ln);
+    ps.forEach((p, j) => {
+      const r = r0 + j * rstep, x = C + r * dx, y = C + r * dy;
+      const nd = document.createElement('div'); nd.className = 'node'; nd.style.left = (x - 54) + 'px'; nd.style.top = (y - 54) + 'px'; nd.style.borderColor = c.color;
+      nd.innerHTML = `<div class="lbl">${esc(p.short)}</div><div class="yr">${p.it.year || ''}</div>`;
+      nd.addEventListener('mousemove', ev => showTip(ev, `${esc(p.it.title)}<span class="m">${esc(c.fam)} &middot; ${p.it.year || ''} &middot; click to read</span>`));
+      nd.addEventListener('mouseleave', () => tip.style.display = 'none');
+      nd.addEventListener('mouseenter', () => highlight(i));
+      nd.addEventListener('click', () => window.open(linkOf(p.it), '_blank'));
+      wrap.appendChild(nd); g.push(nd);
+    });
+    const lr = maxR + 66, lx = C + lr * dx, ly = C + lr * dy;
+    const lab = document.createElement('div'); lab.className = 'caplabel'; lab.style.left = lx + 'px'; lab.style.top = ly + 'px'; lab.style.color = c.color;
+    lab.style.transform = `translate(${dx > 0.3 ? '0' : dx < -0.3 ? '-100%' : '-50%'},${dy > 0.3 ? '0' : dy < -0.3 ? '-100%' : '-50%'})`;
+    lab.textContent = c.fam;
+    lab.addEventListener('mouseenter', () => highlight(i)); lab.addEventListener('mouseleave', () => highlight(null));
+    lab.addEventListener('click', () => {
+      let h = `<div class="fam" style="color:${c.color}">${esc(c.fam)}</div><h2>${esc(c.fam)}</h2>`;
+      h += `<div class="contrast"><b>Traditionally</b> ${esc(c.trad)} <span class="ar">&rarr;</span> <b>now</b> ${esc(c.now)}.</div><div class="ph">Papers</div>`;
+      ps.forEach(p => { h += `<a class="paper" href="${esc(linkOf(p.it))}" target="_blank" rel="noopener">${esc(p.it.title)} <span class="yr">${p.it.year || ''}</span></a>`; });
+      pb.innerHTML = h; panel.classList.add('open'); panel.scrollTop = 0;
+    });
+    wrap.appendChild(lab); g.push(lab);
+    groups.push(g);
+  });
+})();

--- a/methods.css
+++ b/methods.css
@@ -1,0 +1,35 @@
+/* Methodological backbone — the radial "expanded toolchest". */
+.methods-centerpiece{width:100vw;position:relative;left:50%;transform:translateX(-50%);margin:1.4rem 0 0}
+.methods-scroll{overflow-x:auto}
+#methods-radial{position:relative;width:1200px;height:1200px;margin:0 auto}
+#methods-radial svg.lines{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+#methods-radial .hub{position:absolute;width:196px;height:196px;border-radius:50%;background:var(--panel);border:1.5px solid var(--line);
+  display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:20px}
+#methods-radial .hub .ht{font-size:.86rem;font-weight:700;letter-spacing:.07em;color:var(--ink);line-height:1.3}
+#methods-radial .hub .hs{font-size:.76rem;color:var(--faint);margin-top:.5rem;line-height:1.45}
+#methods-radial .node{position:absolute;width:108px;height:108px;border-radius:50%;background:var(--panel);border:2px solid var(--line);
+  display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:10px;cursor:pointer;transition:transform .12s}
+#methods-radial .node:hover{transform:scale(1.08);z-index:5}
+#methods-radial .node .lbl{font-size:.82rem;font-weight:600;color:var(--ink);line-height:1.2}
+#methods-radial .node .yr{font-size:.7rem;color:var(--faint);margin-top:.25rem}
+#methods-radial .caplabel{position:absolute;font-size:.82rem;font-weight:700;letter-spacing:.04em;cursor:pointer;white-space:nowrap}
+#methods-radial .caplabel:hover{text-decoration:underline}
+#methods-radial .dim{opacity:.16;transition:opacity .15s}
+
+#methods-panel{position:fixed;top:0;right:0;height:100%;width:min(440px,92vw);background:var(--bg2);border-left:1px solid var(--line);
+  z-index:80;padding:56px 28px 40px;overflow-y:auto;transform:translateX(100%);transition:transform .2s;box-shadow:-18px 0 50px rgba(0,0,0,.5)}
+#methods-panel.open{transform:none}
+#methods-panel .x{position:absolute;top:16px;right:20px;background:none;border:none;color:var(--muted);font-size:1.7rem;cursor:pointer}
+#methods-panel .x:hover{color:var(--ink)}
+#methods-panel .fam{font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;font-weight:700;margin-bottom:.5rem}
+#methods-panel h2{font-size:1.4rem;margin:0 0 .8rem;line-height:1.25;color:var(--ink)}
+#methods-panel .contrast{font-size:.95rem;color:var(--muted);line-height:1.6;margin:0 0 1.2rem;padding:.8rem .9rem;background:var(--panel);border-radius:9px}
+#methods-panel .contrast b{color:var(--ink)} #methods-panel .contrast .ar{color:var(--accent)}
+#methods-panel .ph{font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faint);font-weight:600;margin-bottom:.5rem}
+#methods-panel a.paper{display:block;color:var(--ink);text-decoration:none;font-size:.92rem;line-height:1.4;padding:.5rem 0;border-top:1px solid rgba(39,48,74,.6)}
+#methods-panel a.paper:first-of-type{border-top:none}
+#methods-panel a.paper:hover{color:var(--accent)} #methods-panel a.paper .yr{color:var(--faint);font-size:.78rem}
+
+#methods-tip{position:fixed;z-index:90;pointer-events:none;display:none;max-width:300px;background:var(--panel);border:1px solid var(--line);
+  border-radius:9px;padding:.55rem .7rem;font-size:.84rem;box-shadow:0 8px 28px rgba(0,0,0,.5)}
+#methods-tip .m{display:block;color:var(--muted);font-size:.74rem;margin-top:.25rem}

--- a/scripts/build_areas.py
+++ b/scripts/build_areas.py
@@ -84,21 +84,8 @@ AREAS = [
     # area-artificial-organisms.html is now hand-built (it carries the AO coverage
     # grid); it is intentionally not generated here.
     # area-applied-domains.html is hand-built (the translation-map deck); do not generate it here.
-    dict(
-        file="area-methodological-backbone.html",
-        kicker="Data &middot; science &middot; mathematics",
-        title="Methodological backbone",
-        labels=[
-            "Quantitative, computational & statistical methods",
-            "Research Methodologies",
-        ],
-        narrative=(
-            "Running beneath every project is a common methodological spine. This area covers the quantitative, "
-            "computational, and statistical methods we use to model environment-behavior relations, along with "
-            "the research methodologies (e.g., measurement, design, and analysis) that let us see interactions "
-            "in the first place and move findings from one level of analysis to the next."),
-        extra="",
-    ),
+    # area-methodological-backbone.html is hand-built (the "expanded toolchest"
+    # radial deck); it is intentionally not generated here.
 ]
 
 


### PR DESCRIPTION
The fourth and final area deck. Hero + a radial 'expanded toolchest' centerpiece: the field's traditional toolkit at the hub, and each of the 19 methods papers radiating outward along its capability spoke (oldest nearest the center, newest farthest). Hover for the paper, click to read, click a spoke label for the 'traditionally -> now' framing. Statistics placed next to Modeling and Machine learning. build_areas.py now generates no area page (all four are hand-built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)