### PR TITLE
Point collaboration mailto buttons to dcox@endicott.edu

### DIFF
--- a/area-applied-domains.html
+++ b/area-applied-domains.html
@@ -94,7 +94,7 @@
                 <p>The thin bridges and the sparser domains are where the next translations live. If you work
                    in one of these settings and want a behavioral-science partner on a question, we would like
                    to hear from you.</p>
-                <a class="cta-big" href="mailto:cox.david.j@gmail.com?subject=Collaboration%20on%20an%20applied%20study">Bring us a problem &rarr;</a>
+                <a class="cta-big" href="mailto:dcox@endicott.edu?subject=Collaboration%20on%20an%20applied%20study">Bring us a problem &rarr;</a>
             </section>
         </main>
 

--- a/area-integrating-principles.html
+++ b/area-integrating-principles.html
@@ -173,7 +173,7 @@
                 <p>The point of the map is the dark. Every open cell is a study no one has run, and an
                    invitation. If one of them is yours, we would like to run it with you. Click an open cell
                    above to propose it, or reach out directly.</p>
-                <a class="cta-big" href="mailto:cox.david.j@gmail.com?subject=Collaboration%20on%20a%20combination%20study">Propose a study with us &rarr;</a>
+                <a class="cta-big" href="mailto:dcox@endicott.edu?subject=Collaboration%20on%20a%20combination%20study">Propose a study with us &rarr;</a>
             </section>
         </main>
 

--- a/area-methodological-backbone.html
+++ b/area-methodological-backbone.html
@@ -81,7 +81,7 @@
                 <p>The fastest way to ask a new question is to pick up a tool you have not used yet. If you want to
                    learn how one of these methods works, or to bring one to a question in your own research, we
                    would like to help. The aim is a field that can ask and answer questions it could not before.</p>
-                <a class="cta-big" href="mailto:cox.david.j@gmail.com?subject=Learning%20a%20new%20method">Learn a new tool with us &rarr;</a>
+                <a class="cta-big" href="mailto:dcox@endicott.edu?subject=Learning%20a%20new%20method">Learn a new tool with us &rarr;</a>
             </section>
         </main>
 

--- a/landscape-render.js
+++ b/landscape-render.js
@@ -64,7 +64,7 @@
       fm.refs.forEach(i => { const a = D.articles[i]; h += `<div class="art"><a href="${esc(a.u)}" target="_blank" rel="noopener">${esc(a.t)}</a><div class="meta">${esc(a.a)}${a.y ? ' &middot; ' + a.y : ''}</div></div>`; });
     } else {
       const subj = encodeURIComponent(`Collaboration: ${rp.label} × ${cp.label}`);
-      h += `<div class="tag open">Open frontier</div><h3>${title}</h3><p class="c">No one has co-studied this pair yet. Want to take it on with us?</p><a class="cta" href="mailto:cox.david.j@gmail.com?subject=${subj}">Propose this study &rarr;</a>`;
+      h += `<div class="tag open">Open frontier</div><h3>${title}</h3><p class="c">No one has co-studied this pair yet. Want to take it on with us?</p><a class="cta" href="mailto:dcox@endicott.edu?subject=${subj}">Propose this study &rarr;</a>`;
     }
     pbody.innerHTML = h; panel.classList.add('open'); panel.scrollTop = 0;
   }


### PR DESCRIPTION
Swaps the collaboration CTA destination (three deck buttons + the combination-matrix open-cell mailto) from the gmail address to dcox@endicott.edu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)