### PR TITLE
Add .gitignore for Python cache and macOS clutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.DS_Store


### PR DESCRIPTION
## Summary
- Adds .gitignore covering scripts/__pycache__/, *.pyc, and .DS_Store so they stop showing up as untracked files